### PR TITLE
Disable IoT security module

### DIFF
--- a/azure_iot/CMakeLists.txt
+++ b/azure_iot/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0079 NEW)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(NX_AZURE_DISABLE_IOT_SECURITY_MODULE OFF CACHE BOOL "Disable Azure IoT Security Module (default is OFF)")
+set(NX_AZURE_DISABLE_IOT_SECURITY_MODULE ON CACHE BOOL "Disable Azure IoT Security Module (default is ON)")
 
 # Project name, version and languages
 project(azure_iot


### PR DESCRIPTION
Current implementation is not functional on GCC due to CMakeLists errors as well as default RAM size.